### PR TITLE
Fix Static IP address editing

### DIFF
--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -90,11 +90,12 @@ fi
 #
 function create_if_config() {
 		address=$(ip -4 addr show dev $1 | awk '/inet/ {print $2}' | cut -d'/' -f1)
-		netmask=$(ifconfig $1 | sed -rn '2s/ .*:(.*)$/\1/p')
+		netmask=$(ip -4 addr show dev $1 | awk '/inet/ {print $2}' | cut -d'/' -f2)
 		gateway=$(route -n | grep 'UG[ \t]' | awk '{print $2}' | sed -n '1p')
 		echo -e "# armbian-config created"
 		echo -e "source /etc/network/interfaces.d/*\n"
-		echo -e "allow-hotplug $2\nno-auto-down $2"
+		echo -e "# Local loopback\nauto lo\niface lo init loopback\n"
+		echo -e "# Interface $2\nallow-hotplug $2\nno-auto-down $2"
 		if [[ "$3" != "fixed" ]]; then
 			echo -e "iface $2 inet dhcp"
 		else
@@ -260,9 +261,10 @@ function ip_editor ()
 	2>&1 1>&3 | {
 		read -r address;read -r netmask;read -r gateway
 		if [[ $? = 0 ]]; then
-				echo -e "# armbian-config created\nsource /etc/network/interfaces.d/*\n\nallow-hotplug $2\
-				\nno-auto-down $2\niface $2 inet static\
-				\n\taddress $address\n\tnetmask $netmask\n\tgateway $gateway\n\tdns-nameservers 8.8.8.8" > $3
+				echo -e "# armbian-config created\nsource /etc/network/interfaces.d/*\n" >$3
+				echo -e "# Local loopback\nauto lo\niface lo inet loopback\n" >> $3
+				echo -e "# Interface $2\nallow-hotplug $2\nno-auto-down $2\niface $2 inet static\
+				\n\taddress $address\n\tnetmask $netmask\n\tgateway $gateway\n\tdns-nameservers 8.8.8.8" >> $3
 		fi
 		}
 }
@@ -505,7 +507,7 @@ function select_default_interface ()
 {
 	IFS=$'\r\n'
 	GLOBIGNORE='*'
-	local ADAPTER=($(ip -4 route ls | grep default | grep -Po '(?<=dev )(\S+)'))
+	local ADAPTER=($(ls /sys/class/net | grep -E -v 'lo|tun'))
 	local LIST=()
 	for i in "${ADAPTER[@]}"
 	do


### PR DESCRIPTION
- select default interface based on sysfs + ignore local loopback
- generate local loopback config lines for static and dhcp config creation
Issue #14 
  