### PR TITLE
Helios4: Add LED script to mdadm conf generated by OMV

### DIFF
--- a/debian-software
+++ b/debian-software
@@ -579,6 +579,7 @@ read TZ </etc/timezone
 debconf-set-selections <<< "postfix postfix/mailname string ${HOSTNAME}"
 debconf-set-selections <<< "postfix postfix/main_mailer_type string 'No configuration'"
 SPACE_NEEDED=$(apt-get --assume-no --allow-unauthenticated --fix-missing --no-install-recommends install openmediavault postfix dirmngr 2>/dev/null | awk -F" " '/additional disk space will be used/ {print $4}')
+SPACE_NEEDED=${SPACE_NEEDED%.*}
 SPACE_AVAIL=$(df -k / | awk -F" " '/\/$/ {printf ("%0.0f",$4/1200); }')
 if [ ${SPACE_AVAIL} -lt ${SPACE_NEEDED} ]; then
 	dialog --backtitle "$BACKTITLE" --title "No space left on device" --msgbox "\nOpenMediaVault needs ${SPACE_NEEDED} MB for installation while only ${SPACE_AVAIL} MB are available." 7 52
@@ -586,7 +587,7 @@ if [ ${SPACE_AVAIL} -lt ${SPACE_NEEDED} ]; then
 fi
 apt-get --allow-unauthenticated install openmediavault-keyring
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7AA630A1EDEE7D73
-debconf-apt-progress -- apt-get -y --allow-unauthenticated --fix-missing --no-install-recommends \
+DEBIAN_FRONTEND=noninteractive debconf-apt-progress -- apt-get -y --allow-unauthenticated --fix-missing --no-install-recommends \
 	-o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" install openmediavault postfix dirmngr
 # Fix multiple sources entry on ARM with OMV4
 sed -i '/stretch-backports/d' /etc/apt/sources.list
@@ -599,7 +600,7 @@ debconf-apt-progress -- apt-get --yes --force-yes --fix-missing --auto-remove --
 # Install flashmemory plugin and netatalk by default, use nice logo for the latter,
 # disable OMV monitoring by default
 . /usr/share/openmediavault/scripts/helper-functions
-debconf-apt-progress -- apt-get -y --fix-missing --no-install-recommends --auto-remove install openmediavault-flashmemory openmediavault-netatalk
+DEBIAN_FRONTEND=noninteractive debconf-apt-progress -- apt-get -y --fix-missing --no-install-recommends --auto-remove install openmediavault-flashmemory openmediavault-netatalk
 AFP_Options="mimic model = Macmini"
 SMB_Options="min receivefile size = 16384\nwrite cache size = 524288\ngetwd cache = yes\nsocket options = TCP_NODELAY IPTOS_LOWDELAY"
 xmlstarlet ed -L -u "/config/services/afp/extraoptions" -v "$(echo -e "${AFP_Options}")" ${OMV_CONFIG_FILE}
@@ -659,6 +660,16 @@ case ${BOARD} in
 		HMP_Fix='; taskset -c -p 4-5 $i '
 		;;
 esac
+
+# Helios4 tweak
+# Make mdadm display fault events on Fault LED
+if [ ${BOARD} == "helios4" ]; then
+	if [ -f /usr/sbin/mdadm-fault-led.sh ]; then
+		sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /usr/share/openmediavault/mkconf/mdadm
+		/usr/sbin/omv-mkconf mdadm
+	fi
+fi
+
 
 # Add a cron job to make NAS processes more snappy
 systemctl status rsyslog >/dev/null 2>&1
@@ -1519,7 +1530,7 @@ fi
 # nameserver backup
 if [ -d /etc/resolvconf/resolv.conf.d ]; then
 	echo 'nameserver 8.8.8.8' > /etc/resolvconf/resolv.conf.d/head
-	resolvconf -u
+	resolvconf -u &> /dev/null
 fi
 
 # Create a safe temporary directory


### PR DESCRIPTION
OMV regenerates from its own templates mdadm.conf file therefore 
removing 
the Helios4 mdadm conf tweak we do in the baseline.

Other fixes :

* Make OMV install non-interactive to not display OMV message about 
omv-initsystem since it is already called by this install script.

* Remove decimal to SPACE_NEEDED variable otherwise the size compare 
(test -lt) won't work.

* Redirect resolconf -u to /dev/null to hide warning message