### PR TITLE
More consistent menu navigation labels

### DIFF
--- a/debian-config
+++ b/debian-config
@@ -8,7 +8,6 @@
 
 
 
-
 #
 # check for root priveleges
 #
@@ -93,7 +92,7 @@ do
 
 	exec 3>&1
 	selection=$(dialog --colors --backtitle "$BACKTITLE" --title " armbian-config " --clear \
-	--cancel-label "Cancel" --menu "\n$MENUTITLE \n \nSupport: \Z1https://forum.armbian.com\Z0\n " \
+	--cancel-label "Exit" --menu "\n$MENUTITLE \n \nSupport: \Z1https://forum.armbian.com\Z0\n " \
 	$LISTLENGHT ${TITLELENGHT} $BOXLENGHT "${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-

--- a/debian-config-functions
+++ b/debian-config-functions
@@ -24,6 +24,7 @@
 # add_choose_user
 # configure_desktop
 
+
 #
 # gather info about the board and start with loading menu
 #

--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -377,7 +377,7 @@ function jobs ()
 
 			else
 				dialog --title " Hostapd service is running " --colors --backtitle "$BACKTITLE" --help-button \
-				--help-label "Cancel" --yes-label  "Stop" --no-label "Edit" --yesno \
+				--help-label "Cancel" --yes-label "Stop" --no-label "Edit" --yesno \
 				"\n\Z1Stop:\Z0 stop providing Access Point\n\n\Z1Edit:\Z0 change basic parameters: SSID, password and channel" 9 70
 			fi
 			exitstatus=$?;
@@ -838,11 +838,11 @@ function jobs ()
 			exec 3>&-
 			mon_x=$(echo $monitor | awk '{print $2}' | sed 's/,//');mon_x=$(( $mon_x / 2 ))
 			mon_y=$(echo $monitor | awk '{print $3}' | sed 's/,//');
-			dialog --title " Update " --backtitle "$BACKTITLE" --no-label "Cancel" --yesno "\nDo you want to update board firmware?" 7 41
+			dialog --title " Update " --backtitle "$BACKTITLE" --no-label "No" --yesno "\nDo you want to update board firmware?" 7 41
 			if [[ $? = 0 ]]; then
 				debconf-apt-progress -- apt-get update
 				debconf-apt-progress -- apt-get -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" -y upgrade
-				dialog --title " Firmware update " --colors --no-label "Cancel" --backtitle "$BACKTITLE" --yesno \
+				dialog --title " Firmware update " --colors --no-label "No" --backtitle "$BACKTITLE" --yesno \
 				"\nFirmware has been updated. Reboot?   " 7 39
 				if [[ $? = 0 ]]; then reboot; fi
 			fi
@@ -1049,7 +1049,7 @@ function jobs ()
 
 			exec 3>&1
 				selection=$(dialog --backtitle "$BACKTITLE" --colors --title "Toggle hardware configuration" --clear --cancel-label \
-				"Exit" --ok-label "Save" --checklist "\nUse \Z1<space>\Z0 to toggle functions and save them. Exit when you are done.\n " \
+				"Back" --ok-label "Save" --checklist "\nUse \Z1<space>\Z0 to toggle functions and save them. Exit when you are done.\n " \
 				$LISTLENGHT 80 $LISTLENGHT "${MOTD[@]}" 2>&1 1>&3)
 				exit_status=$?
 			exec 3>&-
@@ -1144,7 +1144,7 @@ function jobs ()
 				LISTLENGHT="$(($LIST_CONST+${#MOTD[@]}/3))"
 				exec 3>&1
 				selection=$(dialog --backtitle "$BACKTITLE" --title "Toggle motd executing scripts" --clear --cancel-label \
-				"Exit" --ok-label "Save" --checklist "\nChoose what you want to enable or disable:\n " \
+				"Back" --ok-label "Save" --checklist "\nChoose what you want to enable or disable:\n " \
 				$LISTLENGHT 80 15 "${MOTD[@]}" 2>&1 1>&3)
 				exit_status=$?
 				exec 3>&-

--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -14,7 +14,6 @@
 
 
 
-
 #
 # system settings
 #
@@ -136,7 +135,7 @@ while true; do
 
 	exec 3>&1
 	selection=$(DIALOGRC=$temp_rc dialog --colors --backtitle "$BACKTITLE" --title " $sys_title " --clear \
-	--cancel-label "Cancel" --menu "$disclaimer" $LISTLENGHT 68 $BOXLENGHT \
+	--cancel-label "Back" --menu "$disclaimer" $LISTLENGHT 68 $BOXLENGHT \
 	"${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-
@@ -281,7 +280,7 @@ while true; do
 
 	exec 3>&1
 	selection=$(dialog --backtitle "$BACKTITLE" --colors --title " Wired, Wireless, Bluetooth, Hotspot " --clear \
-	--cancel-label "Cancel" --menu "${disclaimer}" $LISTLENGHT 70 $BOXLENGHT \
+	--cancel-label "Back" --menu "${disclaimer}" $LISTLENGHT 70 $BOXLENGHT \
 	"${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-
@@ -317,7 +316,7 @@ while true; do
 
 	exec 3>&1
 	selection=$(dialog --colors --backtitle "$BACKTITLE" --title "Personal settings" --clear \
-	--cancel-label "Cancel" --menu "$disclaimer" $LISTLENGHT 70 $BOXLENGHT \
+	--cancel-label "Back" --menu "$disclaimer" $LISTLENGHT 70 $BOXLENGHT \
 	"${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-
@@ -395,7 +394,7 @@ while true; do
 
 	exec 3>&1
 	selection=$(dialog --backtitle "$BACKTITLE" --title "System and 3rd party software" --clear \
-	--cancel-label "Cancel" --menu "$disclaimer" $LISTLENGHT 70 $BOXLENGHT \
+	--cancel-label "Back" --menu "$disclaimer" $LISTLENGHT 70 $BOXLENGHT \
 	"${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-

--- a/debian-software
+++ b/debian-software
@@ -1622,7 +1622,7 @@ while true; do
 	LISTLENGHT="$((${#LIST[@]}/2))"
 	exec 3>&1
 	selection=$(dialog --backtitle "$BACKTITLE" --title "Installing to $family $distribution" --colors --clear --cancel-label \
-	"Exit" --checklist "\nChoose what you want to install:\n " $LIST_CONST 71 18 "${LIST[@]}" 2>&1 1>&3)
+	"Cancel" --ok-label "Install" --checklist "\nChoose what you want to install:\n " $LIST_CONST 71 18 "${LIST[@]}" 2>&1 1>&3)
 	exit_status=$?
 	exec 3>&-
 	case $exit_status in
@@ -1738,9 +1738,9 @@ if ! is_package_manager_running; then
 		if [[ "$selection" == *Transmission* && "$TRANSMISSION_STATUS" != "on" ]]; then
 			install_transmission
 			selection=${selection//Transmission/}
-			dialog --title "Seed Armbian torrents" --backtitle "$BACKTITLE" --yes-label "Yes" --no-label "Cancel" --yesno "\
-			\nDo you want to help community and seed armbian torrent files? It will ensure faster download for everyone.\
-			\n\nWe need around 80Gb of your space." 11 44
+			dialog --title "Seed Armbian torrents" --backtitle "$BACKTITLE" --yes-label "Yes" --no-label "No" --yesno "\
+			\nDo you want to help the community and seed armbian torrent files? It will ensure faster downloads for everyone.\
+			\n\nApproximately 80GB disk space is required." 11 44
 				if [[ $? = 0 ]]; then
 					install_transmission_seed_armbian_torrents
 				fi


### PR DESCRIPTION
The options at the bottom of certain menus was a bit confusing to me. Some were called "Exit" but simply returned to a prior menu, etc. This is an initial attempt to standardize the menus to be more consistent.

```
Menu -> Action    <Action> <Cancel>
Menu -> Menu      <OK>     <Back>
Menu -> Quit      <OK>     <Exit>
```