### PR TITLE
Use OpenMediaVault external install script

### DIFF
--- a/debian-software
+++ b/debian-software
@@ -609,9 +609,15 @@ case ${BOARD} in
 		;;
 	helios4)
 		# Make mdadm display fault events on Fault LED
+		# NOTE : this is not a permanent approach need to be improved via some OMV core code change
 		if [ -f /usr/sbin/mdadm-fault-led.sh ]; then
-			sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /usr/share/openmediavault/mkconf/mdadm
-			/usr/sbin/omv-mkconf mdadm
+			if [[ "$distribution" == "stretch" ]]; then
+				sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /usr/share/openmediavault/mkconf/mdadm
+				/usr/sbin/omv-mkconf mdadm
+			elif [[ "$distribution" == "buster" ]]; then
+				sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /srv/salt/omv/deploy/mdadm/files/etc-mdadm-mdadm.conf.j2
+				/usr/sbin/omv-salt deploy run mdadm
+			fi
 		fi
 	;;
 esac

--- a/debian-software
+++ b/debian-software
@@ -550,147 +550,36 @@ install_ncp (){
 
 install_omv (){
 #
-# On Debian install OpenMediaVault 3 (Jessie), 4 (Stretch) or 5 (Buster)
+# Install OpenMediaVault on Debian
 #
-# TODO: Some OMV packages lack authentication
-
 if [[ "$family" == "Ubuntu" ]]; then
 	dialog --backtitle "$BACKTITLE" --title "Dependencies not met" --msgbox "\nOpenMediaVault can only be installed on Debian." 7 52
 	sleep 5
 	exit 1
 fi
 
-case $distribution in
-	wheezy|jessie)
-		dialog --backtitle "$BACKTITLE" --title "OMV3 is End of Life" --msgbox "\nUpgrade to a supported Debian release first." 7 52
-		sleep 5
-		exit 1
-		;;
-	stretch)
-		OMV_Name="arrakis"
-		OMV_EXTRAS_URL="https://github.com/OpenMediaVault-Plugin-Developers/packages/raw/master/openmediavault-omvextrasorg_latest_all4.deb"
-		OMV_EXTRA_PACKAGES="openmediavault-flashmemory openmediavault-netatalk"
-		;;
-	buster)
-		dialog --title "Warning" --msgbox "\nPlease be aware that OMV5 is still in beta state, might be functionally broken or not working at all. Report any issues you run into at forum.openmediavault.org.\n\nIf you want to run OMV4 remain on Debian Stretch" 11 56
-		OMV_Name="usul"
-		OMV_EXTRAS_URL="https://github.com/OpenMediaVault-Plugin-Developers/packages/raw/master/openmediavault-omvextrasorg_latest_all5.deb"
-		OMV_EXTRA_PACKAGES="openmediavault-flashmemory"
-		;;
-esac
+# Download OMV install script
+wgeturl="https://github.com/OpenMediaVault-Plugin-Developers/installScript/raw/master/install"
+fancy_wget "$wgeturl" "-O ${TEMP_DIR}/omv_install.sh"
 
-systemctl status log2ram >/dev/null 2>&1 && (systemctl stop log2ram ; systemctl disable log2ram >/dev/null 2>&1; rm /etc/cron.daily/log2ram)
-systemctl status armbian-ramlog >/dev/null 2>&1 && (systemctl stop armbian-ramlog ; systemctl disable armbian-ramlog >/dev/null 2>&1; rm /etc/cron.daily/armbian-ram-logging)
 
-export LANG=en_US.UTF-8
-export DEBIAN_FRONTEND=noninteractive
-export APT_LISTCHANGES_FRONTEND=none
-if [ -f /etc/armbian-release ]; then
-	. /etc/armbian-release
-else
-	sed -i "s/^# en_US.UTF-8/en_US.UTF-8/" /etc/locale.gen
-	locale-gen
+# Remove Crony on Stretch since OMV4 depends on NTP
+if [[ "$distribution" == "stretch" ]]; then
+		apt-get -y -qq remove chrony
 fi
 
-# preserve cpufrequtils settings:
-if [ -f /etc/default/cpufrequtils ]; then
-	. /etc/default/cpufrequtils
-fi
+# Execute install script
+echo "Now installing OpenMediaVault. Be patient please..."
+bash ${TEMP_DIR}/omv_install.sh
 
-# Add OMV sources
-cat > /etc/apt/sources.list.d/openmediavault.list << EOF
-deb https://packages.openmediavault.org/public ${OMV_Name} main
 
-## Uncomment the following line to add software from the proposed repository.
-deb https://packages.openmediavault.org/public ${OMV_Name}-proposed main
-
-## This software is not part of OpenMediaVault, but is offered by third-party
-## developers as a service to OpenMediaVault users.
-# deb https://packages.openmediavault.org/public ${OMV_Name} partner
-EOF
-
-# Install keys
-wget -O "/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.asc" https://packages.openmediavault.org/public/archive.key
-apt-key add "/etc/apt/trusted.gpg.d/openmediavault-archive-keyring.asc"
-debconf-apt-progress -- apt-get update
-debconf-apt-progress -- apt-get --yes install openmediavault-keyring
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 7AA630A1EDEE7D73
-
-# configure install and check for disk space
-read HOSTNAME </etc/hostname
-read TZ </etc/timezone
-debconf-set-selections <<< "postfix postfix/mailname string ${HOSTNAME}"
-debconf-set-selections <<< "postfix postfix/main_mailer_type string 'No configuration'"
-SPACE_NEEDED=$(apt-get --assume-no --allow-unauthenticated --fix-missing --no-install-recommends install openmediavault-keyring openmediavault postfix dirmngr 2>/dev/null | awk -F" " '/additional disk space will be used/ {print $4}')
-SPACE_NEEDED=${SPACE_NEEDED%.*}
-SPACE_AVAIL=$(df -k / | awk -F" " '/\/$/ {printf ("%0.0f",$4/1200); }')
-if [ ${SPACE_AVAIL} -lt ${SPACE_NEEDED} ]; then
-	dialog --backtitle "$BACKTITLE" --title "No space left on device" --msgbox "\nOpenMediaVault needs ${SPACE_NEEDED} MB for installation while only ${SPACE_AVAIL} MB are available." 7 52
-	exit 1
-fi
-
-# main install
-echo "Now installing OMV packages. Be patient please"
-debconf-apt-progress -- apt-get --yes --auto-remove --show-upgraded \
-	--allow-downgrades --allow-change-held-packages \
-	--no-install-recommends \
-	--option Dpkg::Options::="--force-confdef" \
-	--option DPkg::Options::="--force-confold" \
-	install postfix dirmngr openmediavault
-
-# Fix multiple sources entry on ARM with OMV
-sed -i '/stretch-backports/d' /etc/apt/sources.list
-sed -i '/buster-backports/d' /etc/apt/sources.list
-
-# Install OMV-Extras
-FILE="${TEMP_DIR}/omv_extras.deb"; wget "$OMV_EXTRAS_URL" -qO $FILE && dpkg -i $FILE ; rm $FILE
-debconf-apt-progress -- apt-get update
-debconf-apt-progress -- apt-get --yes --force-yes --fix-missing --auto-remove --allow-unauthenticated \
-  --show-upgraded --option DPkg::Options::="--force-confold" dist-upgrade
-
-# Install flashmemory plugin and netatalk on OMV4 by default, use nice logo for the latter,
-# disable OMV monitoring by default
-. /usr/share/openmediavault/scripts/helper-functions
-debconf-apt-progress -- apt-get -y --fix-missing --no-install-recommends --auto-remove install ${OMV_EXTRA_PACKAGES}
-AFP_Options="mimic model = Macmini"
-SMB_Options="min receivefile size = 16384\nwrite cache size = 524288\ngetwd cache = yes\nsocket options = TCP_NODELAY IPTOS_LOWDELAY"
-xmlstarlet ed -L -u "/config/services/afp/extraoptions" -v "$(echo -e "${AFP_Options}")" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/services/smb/extraoptions" -v "$(echo -e "${SMB_Options}")" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/services/flashmemory/enable" -v "1" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/services/ssh/enable" -v "1" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/services/ssh/permitrootlogin" -v "1" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/system/time/ntp/enable" -v "1" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/system/time/timezone" -v "${TZ}" ${OMV_CONFIG_FILE}
-xmlstarlet ed -L -u "/config/system/network/dns/hostname" -v "${HOSTNAME}" ${OMV_CONFIG_FILE}
-/usr/sbin/omv-rpc -u admin "perfstats" "set" '{"enable":false}'
-/usr/sbin/omv-rpc -u admin "config" "applyChanges" '{ "modules": ["monit","rrdcached","collectd"],"force": true }'
-sed -i 's|-j /var/lib/rrdcached/journal/ ||' /etc/init.d/rrdcached
-/sbin/folder2ram -enablesystemd 2>/dev/null
-
-# Prevent accidentally destroying board performance by clicking around in OMV UI since
-# OMV sets 'powersave' governor when touching 'Power Management' settings.
-if [ ! -f /etc/default/cpufrequtils ]; then
-	DEFAULT_GOV="$(zgrep "^CONFIG_CPU_FREQ_DEFAULT_GOV_" /proc/config.gz 2>/dev/null | sed 's/CONFIG_CPU_FREQ_DEFAULT_GOV_//')"
-	if [ -n "${DEFAULT_GOV}" ]; then
-		GOVERNOR=$(cut -f1 -d= <<<"${DEFAULT_GOV}" | tr '[:upper:]' '[:lower:]')
-	else
-		GOVERNOR=ondemand
-	fi
-	MIN_SPEED="0"
-	MAX_SPEED="0"
-fi
-echo -e "OMV_CPUFREQUTILS_GOVERNOR=${GOVERNOR}" >>/etc/default/openmediavault
-echo -e "OMV_CPUFREQUTILS_MINSPEED=${MIN_SPEED}" >>/etc/default/openmediavault
-echo -e "OMV_CPUFREQUTILS_MAXSPEED=${MAX_SPEED}" >>/etc/default/openmediavault
-if [ -x /usr/sbin/omv-mkconf ]; then
-	for i in netatalk samba flashmemory ssh ntp timezone monit rrdcached collectd cpufrequtils ; do
-		/usr/sbin/omv-mkconf $i
-	done
-fi
+# Board Specific Tweak
+echo "Now applying board tweak if required..."
 
 # Hardkernel Cloudshell 1 and 2 fixes, read the whole thread for details:
 # https://forum.openmediavault.org/index.php/Thread/17855
 lsusb | grep -q -i "05e3:0735" && sed -i "/exit 0/i echo 20 > /sys/class/block/sda/queue/max_sectors_kb" /etc/rc.local
+
 case ${BOARD} in
 	odroidxu4)
 		HMP_Fix='; taskset -c -p 4-7 $i '
@@ -706,56 +595,15 @@ case ${BOARD} in
 			done
 		fi
 		;;
-	bananapim3|nanopifire3|nanopct3plus|nanopim3)
-		HMP_Fix='; taskset -c -p 4-7 $i '
-		;;
-	*rk3399*|*edge*|nanopct4|nanopim4|nanopineo4|renegade-elite|rockpi-4*|rockpro64)
-		HMP_Fix='; taskset -c -p 4-5 $i '
-		;;
-	odroidn2)
-		HMP_Fix='; taskset -c -p 2-5 $i '
-		;;
-esac
-
-# Helios4 tweak
-# Make mdadm display fault events on Fault LED
-if [ ${BOARD} == "helios4" ]; then
-	if [ -f /usr/sbin/mdadm-fault-led.sh ]; then
-		sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /usr/share/openmediavault/mkconf/mdadm
-		/usr/sbin/omv-mkconf mdadm
-	fi
-fi
-
-# Add a cron job to make NAS processes more snappy and silence rsyslog
-systemctl status rsyslog >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-	echo ':msg, contains, "do ionice -c1" ~' >/etc/rsyslog.d/omv-armbian.conf
-	echo ':msg, contains, "action " ~' >>/etc/rsyslog.d/omv-armbian.conf
-	echo ':msg, contains, "netsnmp_assert" ~' >>/etc/rsyslog.d/omv-armbian.conf
-	echo ':msg, contains, "Failed to initiate sched scan" ~' >>/etc/rsyslog.d/omv-armbian.conf
-	systemctl restart rsyslog
-fi
-echo "* * * * * root for i in \`pgrep \"ftpd|nfsiod|smbd|afpd|cnid\"\` ; do ionice -c1 -p \$i ${HMP_Fix}; done >/dev/null 2>&1" >/etc/cron.d/make_nas_processes_faster
-chmod 600 /etc/cron.d/make_nas_processes_faster
-
-# finishing steps
-case $distribution in
-	stretch)
-		# Fix python bug upstream Debian 9 obviously ignores
-		if [ -f /usr/lib/python3.5/weakref.py ]; then
-			wget -O /usr/lib/python3.5/weakref.py \
-			https://raw.githubusercontent.com/python/cpython/9cd7e17640a49635d1c1f8c2989578a8fc2c1de6/Lib/weakref.py
+	helios4)
+		# Make mdadm display fault events on Fault LED
+		if [ -f /usr/sbin/mdadm-fault-led.sh ]; then
+			sed -i -e "/HOMEHOST/a \\\n# Trigger Fault Led script when an event is detected\\nPROGRAM \/usr\/sbin\/mdadm-fault-led.sh" /usr/share/openmediavault/mkconf/mdadm
+			/usr/sbin/omv-mkconf mdadm
 		fi
-		/usr/sbin/omv-initsystem
-		;;
-	buster)
-		/usr/sbin/omv-confdbadm populate
-		;;
+	;;
 esac
 }
-
-
-
 
 install_tvheadend ()
 {
@@ -1331,7 +1179,7 @@ install_Virus ()
 packets="amavisd-new spamassassin clamav clamav-daemon unzip bzip2 arj p7zip unrar-free rpm nomarch lzop \
 cabextract apt-listchanges libnet-ldap-perl libauthen-sasl-perl clamav-docs daemon libio-string-perl libio-socket-ssl-perl \
 libnet-ident-perl zip libnet-dns-perl postgrey"
-if [[ $distribution != "bionic" ]] && [[ $distribution != "buster" ]]; then 
+if [[ $distribution != "bionic" ]] && [[ $distribution != "buster" ]]; then
     packets=$packets" zoo"
 fi
 if [[ $distribution != "buster" ]]; then packets=$packets" ripole"; fi

--- a/debian-software
+++ b/debian-software
@@ -552,16 +552,29 @@ install_omv (){
 #
 # Install OpenMediaVault on Debian
 #
+
+# Don't allow installation on Ubuntu
 if [[ "$family" == "Ubuntu" ]]; then
 	dialog --backtitle "$BACKTITLE" --title "Dependencies not met" --msgbox "\nOpenMediaVault can only be installed on Debian." 7 52
 	sleep 5
 	exit 1
 fi
 
+# Warning / Notice before install
+case $distribution in
+	wheezy|jessie)
+		dialog --backtitle "$BACKTITLE" --title "OMV3 is End of Life" --msgbox "\nUpgrade to a supported OS : Debian Stretch or Buster." 7 52
+		sleep 5
+		exit 1
+		;;
+	buster)
+		dialog --title "Warning" --msgbox "\nPlease be aware that OMV5 is still in beta state. Report any issues you run into at forum.openmediavault.org.\n\nIf you want to run Stable OMV4 you need to run Debian Stretch." 11 56
+		;;
+esac
+
 # Download OMV install script
 wgeturl="https://github.com/OpenMediaVault-Plugin-Developers/installScript/raw/master/install"
 fancy_wget "$wgeturl" "-O ${TEMP_DIR}/omv_install.sh"
-
 
 # Remove Crony on Stretch since OMV4 depends on NTP
 if [[ "$distribution" == "stretch" ]]; then
@@ -571,7 +584,6 @@ fi
 # Execute install script
 echo "Now installing OpenMediaVault. Be patient please..."
 bash ${TEMP_DIR}/omv_install.sh
-
 
 # Board Specific Tweak
 echo "Now applying board tweak if required..."

--- a/debian-software
+++ b/debian-software
@@ -582,8 +582,8 @@ if [[ "$distribution" == "stretch" ]]; then
 fi
 
 # Execute install script
-echo "Now installing OpenMediaVault. Be patient please..."
-bash ${TEMP_DIR}/omv_install.sh
+echo "Now installing OpenMediaVault. Be patient, it will take several minutes..."
+bash ${TEMP_DIR}/omv_install.sh &>> /var/log/omv_install.log
 
 # Board Specific Tweak
 echo "Now applying board tweak if required..."


### PR DESCRIPTION
This change is driven by the discussion #76 and aim to simplify the work and maintenance effort of OMV install function in Armbian-config by calling the OMV install script maintained by their team (@ryecoaaron). This way on our side we focus on board tweak, while OMV team focus on their install script. 

- OMV4 / Stretch install works
- OMV5 / Buster install works

However I have only tested on Helios4 board, so would appreciate if 2-3 of you (that includes you @ryecoaaron) test on other boards.

I have silenced the install output because too much gibberish which can be confusing for the user. If you want to check the log while it's installing

`tail -f /var/log/omv_install.log`

So let's test first before merging ;-)
