### PR TITLE
Modify URL for USB redirector

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -77,14 +77,16 @@ function jobs ()
 			IFS='.' read -a array <<< $(uname -r)
 			[[ -z $(dpkg -l | grep linux-headers) ]] && debconf-apt-progress -- apt-get -y \
 			install linux-headers${TARGET_BRANCH}-${TARGET_FAMILY}
-			rm -rf /usr/src/usb-redirector-linux-arm-eabi
 			if (( "${array[0]}" == "4" )) && (( "${array[1]}" >= "1" )); then
-				wget -qO- http://www.incentivespro.com/usb-redirector-linux-arm-eabi.tar.gz | tar xz -C /usr/src
+				rm -rf /usr/src/usb-redirector-linux-arm-gnueabi
+				wget -qO- https://www.incentivespro.com/usb-redirector-linux-arm-gnueabi.tar.gz | tar xz -C /usr/src
+				cd /usr/src/usb-redirector-linux-arm-gnueabi/
 			else
+				rm -rf /usr/src/usb-redirector-linux-arm-eabi
 				wget -qO- https://raw.githubusercontent.com/armbian/build/master/packages/blobs/usb-redirector/usb-redirector-old.tgz \
 				| tar xz -C /usr/src
+				cd /usr/src/usb-redirector-linux-arm-eabi/
 			fi
-			cd /usr/src/usb-redirector-linux-arm-eabi/
 			./installer.sh install
 			sleep 3
 			check_port "32032" "USB Redirector"


### PR DESCRIPTION
The link of ```http://www.incentivespro.com/usb-redirector-linux-arm-eabi.tar.gz``` was  permanently moved to ```https://www.incentivespro.com/usb-redirector-linux-arm-gnueabi.tar.gz```, and the name of extracted directory is different as well.

![image](https://user-images.githubusercontent.com/20593333/84159959-3f32bb00-aaa0-11ea-85ee-c284ac2aa963.png)
