### PR TITLE
Adds rockchip overlay support

### DIFF
--- a/debian-config-functions
+++ b/debian-config-functions
@@ -58,6 +58,7 @@ function main(){
 	OVERLAYDIR="/boot/dtb/overlay";
 	[[ "$LINUXFAMILY" == "sunxi64" ]] && OVERLAYDIR="/boot/dtb/allwinner/overlay";
 	[[ "$LINUXFAMILY" == "meson64" ]] && OVERLAYDIR="/boot/dtb/amlogic/overlay";
+	[[ "$LINUXFAMILY" == "rockchip" ]] && OVERLAYDIR="/boot/dtb/rockchip/overlay";
 	# detect desktop
 	check_desktop
 	dialog --backtitle "$BACKTITLE" --title "Please wait" --infobox "\nLoading Armbian configuration utility ... " 5 45


### PR DESCRIPTION
I noticed that on my NanoPi M4V2 is missing the "Hardware" entry on armbian-config, I believe the cause for that is the missing headers folder for "rockchip" Linux family.