### PR TITLE
Corrects typo on "rockship64" Linux family

### DIFF
--- a/debian-config-functions
+++ b/debian-config-functions
@@ -58,7 +58,7 @@ function main(){
 	OVERLAYDIR="/boot/dtb/overlay";
 	[[ "$LINUXFAMILY" == "sunxi64" ]] && OVERLAYDIR="/boot/dtb/allwinner/overlay";
 	[[ "$LINUXFAMILY" == "meson64" ]] && OVERLAYDIR="/boot/dtb/amlogic/overlay";
-	[[ "$LINUXFAMILY" == "rockchip" ]] && OVERLAYDIR="/boot/dtb/rockchip/overlay";
+	[[ "$LINUXFAMILY" == "rockchip64" ]] && OVERLAYDIR="/boot/dtb/rockchip/overlay";
 	# detect desktop
 	check_desktop
 	dialog --backtitle "$BACKTITLE" --title "Please wait" --infobox "\nLoading Armbian configuration utility ... " 5 45


### PR DESCRIPTION
It seems I made a typo on my previous PR https://github.com/armbian/config/pull/106, the Linux family should be "rockchip64" instead of "rockchip", thus matching what I get when I do `cat /etc/armbian-release` on my NanoPi M4V2.