### PR TITLE
Fix cpu frequency issue

### DIFF
--- a/debian-config-functions
+++ b/debian-config-functions
@@ -342,7 +342,7 @@ function generic_select()
 	done
 	LIST_LENGTH=$((${#LIST[@]}/2));
 	if [ "$LIST_LENGTH" -eq 1 ]; then
-		PARAMETER=${PARAMETER[0]}
+		PARAMETER=${LIST[0]}
 	else
 		exec 3>&1
 		PARAMETER=$(dialog --nocancel --backtitle "$BACKTITLE" --no-collapse \


### PR DESCRIPTION
Hi,

If I choose the highest cpu frequency as minium like the following photo

![image](https://user-images.githubusercontent.com/20593333/94144601-f1ea2600-fea3-11ea-9787-1bdcc848e5d1.png)

then after choose cpu governor, the maxium cpu frequency will be set as the lowest one like the following photo

![image](https://user-images.githubusercontent.com/20593333/94144791-2c53c300-fea4-11ea-85da-f763564a71c4.png)
 