### PR TITLE
Fixed kernel switching for rk3399 family

### DIFF
--- a/debian-config-functions
+++ b/debian-config-functions
@@ -444,10 +444,11 @@ function other_kernel_version ()
 	[[ ${LINUXFAMILY} == cubox || ${LINUXFAMILY} == udoo ]] && LINUXFAMILY=imx6
 	[[ ${BOARD} == odroidc2 || ${BOARD} == kvim1 || ${BOARD} == lafrite || ${BOARD} == lepotato || ${BOARD} == nanopik2-s905 ]] && HIDDEN="legacy"
 	[[ ${LINUXFAMILY} == odroidn2 ]] && LINUXFAMILY=meson64
+	[[ ${BOARDFAMILY} == rk3399 ]] && LINUXFAMILY="((current|dev)-rockchip64|legacy-rk3399)"
 
 	# check what is available from the repository
 	debconf-apt-progress -- apt-get update
-	LIST=($(apt-cache show linux-image*${LINUXFAMILY} | grep -E  "Package:|Version:|version:" \
+	LIST=($(apt-cache show linux-image.*${LINUXFAMILY} | grep -E  "Package:|Version:|version:" \
 	| grep -v "Config-Version" | sed -n -e 's/^.*: //p' | sed 's/\.$//g'))
 	new_list=()
 


### PR DESCRIPTION
Closes: [AR-587]

Currently rk3399 boards are switched to legacy-rockchip64 kernel which usually does not even have the correct device tree installed and renders the board unbootable.

This change switched the image search from glob to equivalent regex (`*` -> `.*`) and adds special treatment for rk3399.

[AR-587]: https://armbian.atlassian.net/browse/AR-587