### PR TITLE
Add submodule to select APT mirror from URL

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1617,6 +1617,33 @@ function jobs ()
 		echo "Device tree modifications finished!"
 	;;
 
+	"Mirrors")
+
+		# Unique mirrors to simple list
+		mirror_url="https://apt.armbian.com/mirrors"
+		readarray -t mirror_list <<< $(wget -qO- "${mirror_url}" | jq -r '.[] | .[]' | sort | uniq)
+
+		LIST=()
+		for mirror in "${mirror_list[@]}"; do
+			LIST+=( "$[ ${#LIST[@]} / 2 ]" "${mirror}" )
+		done
+
+		exec 3>&1
+		selection=$(dialog --colors --backtitle "${BACKTITLE}" --title " Select APT mirror " --clear --menu "Select mirror" 0 0 0 "${LIST[@]}" 2>&1 1>&3)
+		exit_status=$?
+		exec 3>&-
+		clear
+
+		if [ $exit_status -eq 0 ]; then
+			# Reconfigure apt
+			codename=$(lsb_release -sc)
+			mirror=${mirror_list[$selection]}
+			echo "deb ${mirror} ${codename} main ${codename}-utils ${codename}-desktop" > /etc/apt/sources.list.d/armbian.list
+			apt-get update
+			echo "Software mirror updated!"
+		fi
+		;;
+
 	esac
 
 

--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1620,8 +1620,10 @@ function jobs ()
 	"Mirrors")
 
 		# Unique mirrors to simple list
+		default_url="http://apt.armbian.com"
 		mirror_url="https://apt.armbian.com/mirrors"
 		readarray -t mirror_list <<< $(wget -qO- "${mirror_url}" | jq -r '.[] | .[]' | sort | uniq)
+                mirror_list=( "${default_url}" "${mirror_list[@]}" )
 
 		LIST=()
 		for mirror in "${mirror_list[@]}"; do
@@ -1640,7 +1642,6 @@ function jobs ()
 			mirror=${mirror_list[$selection]}
 			echo "deb ${mirror} ${codename} main ${codename}-utils ${codename}-desktop" > /etc/apt/sources.list.d/armbian.list
 			apt-get update
-			echo "Software mirror updated!"
 		fi
 		;;
 

--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1619,19 +1619,25 @@ function jobs ()
 
 	"Mirrors")
 
-		# Unique mirrors to simple list
-		default_url="http://apt.armbian.com"
-		mirror_url="https://apt.armbian.com/mirrors"
-		readarray -t mirror_list <<< $(wget -qO- "${mirror_url}" | jq -r '.[] | .[]' | sort | uniq)
-                mirror_list=( "${default_url}" "${mirror_list[@]}" )
+		# Default automated mirror
+		url="http://apt.armbian.com"
+		LIST=( "0" "Automated" )
+		mirrors=( "${url}" )
 
-		LIST=()
-		for mirror in "${mirror_list[@]}"; do
-			LIST+=( "$[ ${#LIST[@]} / 2 ]" "${mirror}" )
+		# Mirrors for each region
+		for region in $(wget -qO- "${url}/regions" | jq -r '.[]' | sort | grep -v default); do
+			LIST+=( "${#mirrors[@]}" "Region ${region}" )
+			mirrors+=( "${url}/region/${region}/" )
+		done
+
+		# Individual mirrors
+		for mirror in $(wget -qO- "${url}/mirrors" | jq -r '.[] | .[]' | sort | uniq); do
+			LIST+=( "${#mirrors[@]}" "${mirror}" )
+			mirrors+=( "${mirror}" )
 		done
 
 		exec 3>&1
-		selection=$(dialog --colors --backtitle "${BACKTITLE}" --title " Select APT mirror " --clear --menu "Select mirror" 0 0 0 "${LIST[@]}" 2>&1 1>&3)
+		selection=$(dialog --colors --backtitle "${BACKTITLE}" --title " Select APT mirror " --clear --menu "Select mirror" 0 0 10 "${LIST[@]}" 2>&1 1>&3)
 		exit_status=$?
 		exec 3>&-
 		clear
@@ -1639,7 +1645,7 @@ function jobs ()
 		if [ $exit_status -eq 0 ]; then
 			# Reconfigure apt
 			codename=$(lsb_release -sc)
-			mirror=${mirror_list[$selection]}
+			mirror=${mirrors[$selection]}
 			echo "deb ${mirror} ${codename} main ${codename}-utils ${codename}-desktop" > /etc/apt/sources.list.d/armbian.list
 			apt-get update
 		fi

--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -353,6 +353,7 @@ while true; do
 	check_desktop
 
 	LIST=()
+        LIST+=( "Mirrors" "Reconfigure APT mirrors" )
 	[[ -f /usr/bin/softy || -f softy ]] && LIST+=( "Softy" "3rd party applications installer" )
 	[[ -f /usr/bin/h3consumption && "$LINUXFAMILY" = "sun8i" && "$BRANCH" = "default" ]] && \
 	LIST+=( "Consumption" "Control board consumption" )

--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -319,6 +319,7 @@ while true; do
 	LIST+=( "Keyboard" "Change console keyboard layout (\Z5$(cat /etc/default/keyboard | grep XKBLAYOUT | grep -o '".*"' | sed 's/"//g')\Z0)")
 	LIST+=( "Hostname" "Change your hostname \Z5($(cat /etc/hostname))\Z0" )
 	LIST+=( "Welcome" "Toggle welcome screen items" )
+        LIST+=( "Mirrors" "Reconfigure APT mirrors" )
 
 	# count number of menu items to adjust window sizee
 	LISTLENGTH="$((6+${#LIST[@]}/2))"
@@ -353,7 +354,6 @@ while true; do
 	check_desktop
 
 	LIST=()
-        LIST+=( "Mirrors" "Reconfigure APT mirrors" )
 	[[ -f /usr/bin/softy || -f softy ]] && LIST+=( "Softy" "3rd party applications installer" )
 	[[ -f /usr/bin/h3consumption && "$LINUXFAMILY" = "sun8i" && "$BRANCH" = "default" ]] && \
 	LIST+=( "Consumption" "Control board consumption" )

--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -325,13 +325,15 @@ while true; do
 	LISTLENGTH="$((6+${#LIST[@]}/2))"
 	BOXLENGTH=${#LIST[@]}
 
-	exec 3>&1
-	selection=$(dialog --colors --backtitle "$BACKTITLE" --title "Personal settings" --clear \
-	--cancel-label "Back" --menu "$disclaimer" $LISTLENGTH 70 $BOXLENGTH \
-	"${LIST[@]}" 2>&1 1>&3)
-	exit_status=$?
-	exec 3>&-
-	[[ $exit_status == $DIALOG_CANCEL || $exit_status == $DIALOG_ESC ]] && clear && break
+	if [[ -z $selection ]]; then
+		exec 3>&1
+		selection=$(dialog --colors --backtitle "$BACKTITLE" --title "Personal settings" --clear \
+		--cancel-label "Back" --menu "$disclaimer" $LISTLENGTH 70 $BOXLENGTH \
+		"${LIST[@]}" 2>&1 1>&3)
+		exit_status=$?
+		exec 3>&-
+		[[ $exit_status == $DIALOG_CANCEL || $exit_status == $DIALOG_ESC ]] && clear && break
+	fi
 
 	# run main function
 	jobs "$selection"


### PR DESCRIPTION
Possible patch to provide functionality requested in Issue #120.

Considered doing something more complicated given that there are mirrors listed for various regions.

However, there's currently only two unique mirrors, and "https://minio.k-space.ee/armbian/apt" is listed multiple times under "default".

So, doing the stupid simple thing for now.