### PR TITLE
Exclude unavailable interface for nmcli

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -367,7 +367,7 @@ function jobs ()
 				if [[ -n $SYSTEMDNET ]]; then
 					systemd_ip_editor "${SELECTED_ADAPTER}"
 				else
-					if [[ -n $(LC_ALL=C nmcli device status | grep $SELECTED_ADAPTER ) ]]; then
+					if [[ -n $(LC_ALL=C nmcli device status | grep $SELECTED_ADAPTER | grep -v unavailable ) ]]; then
 						nm_ip_editor "$SELECTED_ADAPTER"
 					else
 						ip_editor "$SELECTED_ADAPTER" "$SELECTED_ADAPTER" "/etc/network/interfaces"


### PR DESCRIPTION
If network interface is configured in `/etc/network/interface`, `nmcli device status` will indicate the interface as `unavailable`, so we should add `grep -v unavailable`, then we can use `ip_editor` instead of `nm_ip_editor` to handle setting static IP