### PR TITLE
Remove deprecated code and fix typo

### DIFF
--- a/debian-software
+++ b/debian-software
@@ -152,10 +152,10 @@ function check_status
 	LIST+=( "Plex" "$DESCRIPTION" "$PLEX_STATUS" )
 
 	# Emby server
-	AMBY_STATUS="$((check_if_installed emby-server) \
+	EMBY_STATUS="$((check_if_installed emby-server) \
 	&& echo "on" || echo "off" )"
 	alive_port "Emby server" "8096"
-	LIST+=( "Emby" "$DESCRIPTION" "$AMBY_STATUS" )
+	LIST+=( "Emby" "$DESCRIPTION" "$EMBY_STATUS" )
 
 	# Radarr
 	RADARR_STATUS="$([[ -d /opt/Radarr ]] && echo "on" || echo "off" )"
@@ -1689,11 +1689,6 @@ if ! is_package_manager_running; then
 		if [[ "$selection" == *Hassio* && "$HASS_STATUS" != "on" ]]; then
 			install_hassio
 			selection=${selection//Hassio/}
-		fi
-
-		if [[ "$selection" == *OpenHAB2 && "$OPENHAB2_STATUS" != "on" ]]; then
-			install_openhab2
-			selection=${selection//OpenHAB2/}
 		fi
 
 		if [[ "$selection" == *OpenHAB3 && "$OPENHAB_STATUS" != "on" ]]; then

--- a/debian-software
+++ b/debian-software
@@ -1691,7 +1691,7 @@ if ! is_package_manager_running; then
 			selection=${selection//Hassio/}
 		fi
 
-		if [[ "$selection" == *OpenHAB3 && "$OPENHAB_STATUS" != "on" ]]; then
+		if [[ "$selection" == *OpenHAB && "$OPENHAB_STATUS" != "on" ]]; then
 			install_openhab
 			selection=${selection//OpenHAB/}
 		fi


### PR DESCRIPTION
Hi, 

For the deprecated code, I noticed that `install_openhab2` was removed in this [commit](https://github.com/armbian/config/commit/1e970ac371621fde695b86af9ea62cdcfd14971c) , so I guess that the following should be removed as well

https://github.com/armbian/config/blob/1e970ac371621fde695b86af9ea62cdcfd14971c/debian-software#L1694-L1698

For the typo, I found that there are two variables, `AMBY_STATUS` amd `EMBY_STATUS`, I assume that `AMBY_STATUS` should be `EMBY_STATUS`

```
root@localhost:~/config# grep -r "EMBY_STATUS"
debian-software:                if [[ "$selection" == *Emby* && "$EMBY_STATUS" != "on" ]]; then


root@localhost:~/config# grep -r "AMBY_STATUS"
debian-software:        AMBY_STATUS="$((check_if_installed emby-server) \
debian-software:        LIST+=( "Emby" "$DESCRIPTION" "$AMBY_STATUS" )
```

