### PR TITLE
docker.io from distro repo has worked since debian stretch

### DIFF
--- a/debian-software
+++ b/debian-software
@@ -639,17 +639,8 @@ fi
 
 install_docker ()
 {
-curl -fsSL "https://download.docker.com/linux/debian/gpg" | apt-key add -qq - > /dev/null 2>&1
 debconf-apt-progress -- apt-get update
-if [[ $distribution == hirsute || $distribution == focal || $distribution == bionic ]]; then
-echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/ubuntu focal stable" > \
-/etc/apt/sources.list.d/docker.list
 debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker.io
-else
-echo "deb [arch=$(dpkg --print-architecture)] https://download.docker.com/linux/debian buster stable" >\
-/etc/apt/sources.list.d/docker.list
-debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker-ce docker-ce-cli containerd.io
-fi
 }
 
 


### PR DESCRIPTION
stop the insanity docker.io from distro repo has worked since debian.

install docker is breaking more than working.. native distro is fine now.