### PR TITLE
AR-1142 - refactor install_docker to be based on the family

### DIFF
--- a/debian-software
+++ b/debian-software
@@ -638,30 +638,27 @@ fi
 
 install_docker ()
 {
-case $distribution in
-	jammy)
-		mkdir -p /etc/apt/keyrings
+mkdir -p /etc/apt/keyrings
+
+case $family in
+	Ubuntu)
+		# https://docs.docker.com/engine/install/ubuntu/
 		curl -fsSL https://download.docker.com/linux/ubuntu/gpg \
 			| gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 		echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" \
 			> /etc/apt/sources.list.d/docker.list
-		debconf-apt-progress -- apt-get update
-		debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker-ce docker-ce-cli containerd.io
 	;;
-	bullseye|buster)
-		mkdir -p /etc/apt/keyrings
+	Debian)
+		# https://docs.docker.com/engine/install/debian/
 		curl -fsSL https://download.docker.com/linux/debian/gpg \
 			| gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-		echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" > \
-			/etc/apt/sources.list.d/docker.list
-		debconf-apt-progress -- apt-get update
-		debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker-ce docker-ce-cli containerd.io
-	;;
-	*)
-		debconf-apt-progress -- apt-get update
-		debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker.io
+		echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(lsb_release -cs) stable" \
+			> /etc/apt/sources.list.d/docker.list
 	;;
 esac
+
+debconf-apt-progress -- apt-get update
+debconf-apt-progress -- apt-get install -y -qq --no-install-recommends docker-ce docker-ce-cli containerd.io
 }
 
 


### PR DESCRIPTION
Hi

**Motivation**
This PR was initially motivated by the issue https://armbian.atlassian.net/browse/AR-1142

Upon checking the code, I've noticed it was not exactly as mentioned in the issue https://github.com/armbian/config/blob/c9a9b494c3069807471bb00c0336566cd186f6d9/debian-software#L649
Still, I believe there was yet room for improvement, thus this PR 😄 

After reviewing the `install_docker` function, I've noticed that it is still tied to specific Debian/Ubuntu versions. In my opinion this is not desired, as will require further maintenance in the future, in order to support newer linux versions.

---

**Changes**

1. I've changed the logic of the referred function so it works based on the **linux family**, thus following the official docker install guidelines. This will, _hopefully_, ensure that it will be able to install Docker against any current AND future Debian/Ubuntu versions, without any further changes
   * Debian: https://docs.docker.com/engine/install/debian/#install-using-the-repository
   * Ubuntu: https://docs.docker.com/engine/install/ubuntu/#install-using-the-repository
2. I've restructured the function code in order to remove some duplicated statements

---

**Tests**

Installation of Docker, using the tool on a freshly installed:
* ✅ Ubuntu 22.04.1 (jammy)
* ✅ Ubuntu 18.04.5 (bionic) - proving it is not only forward compatible, but also backwards compatible 😄 

**Note**: In order to speed-up the test process, I've done both tests using WSL2 on Windows 10 (AMD64). I know it's not ideal, but I believe the code, as is, should be independent from the HW architecture.

---

If you have any question, feedback or suggestion, please do not hesitate to say so :)
Thank you