### PR TITLE
If armbianEnv.txt happens to have a "user_overlays" line but no "over…

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1221,7 +1221,7 @@ function jobs ()
 					CHANGES="true"
 					newoverlays="$(echo "$selection" | sed "s|[^ ]* *|&|g")"
 					sed -i "s/^overlays=.*/overlays=$newoverlays/" /boot/armbianEnv.txt
-					if ! grep -q "overlays" /boot/armbianEnv.txt; then echo "overlays=$newoverlays" >> /boot/armbianEnv.txt; fi
+					if ! grep -q "^overlays" /boot/armbianEnv.txt; then echo "overlays=$newoverlays" >> /boot/armbianEnv.txt; fi
 					if [[ -z $newoverlays ]]; then sed -i "/^overlays/d" /boot/armbianEnv.txt; fi
 					sync
 				;;


### PR DESCRIPTION
…lays" line, adding a first overlay will fail because the script matches the "user_overlays" but after that will fail to append to the non existing line. The grep has to match the begin of line "^overlay" to avoid ambiguity.