### PR TITLE
Armbian-config Set CPU speed and governor fix and warning.

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1121,19 +1121,31 @@ function jobs ()
 		[[ $(grep -c '^processor' /proc/cpuinfo) -gt 4 ]] && POLICY="policy4"
 		[[ ! -d /sys/devices/system/cpu/cpufreq/policy4 ]] && POLICY="policy0"
 		[[ -d /sys/devices/system/cpu/cpufreq/policy0 && -d /sys/devices/system/cpu/cpufreq/policy2 ]] && POLICY="policy2"
-		generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_frequencies 2>/dev/null || cat /sys/devices/system/cpu/cpufreq/$POLICY/cpuinfo_min_freq 2>/dev/null)" "Select minimum CPU speed"
-		MIN_SPEED=$PARAMETER
-		generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_frequencies 2>/dev/null || cat /sys/devices/system/cpu/cpufreq/$POLICY/cpuinfo_max_freq 2>/dev/null)" "Select maximum CPU speed" "$PARAMETER"
-		MAX_SPEED=$PARAMETER
-		generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_governors)" "Select CPU governor"
-		GOVERNOR=$PARAMETER
+		if [[ -n $(grep -w "ENABLE=true" /etc/default/cpufrequtils) ]]; then
+		   generic_select "true false" "Toggle ENABLE CPU frequency utilities."
+		else
+		   generic_select "false true" "Toggle ENABLE CPU frequency utilities."
+		fi
+		ENABLE=$PARAMETER
+		if [[ $ENABLE == true ]]; then
+			dialog --title " Warning: DEPRECATED. THIS MAY NOT WORK ON SOME BOARDS "
+			generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_frequencies 2>/dev/null || cat /sys/devices/system/cpu/cpufreq/$POLICY/cpuinfo_min_freq 2>/dev/null)" "Select minimum CPU speed"
+			MIN_SPEED=$PARAMETER
+			generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_frequencies 2>/dev/null || cat /sys/devices/system/cpu/cpufreq/$POLICY/cpuinfo_max_freq 2>/dev/null)" "Select maximum CPU speed" "$PARAMETER"
+			MAX_SPEED=$PARAMETER
+			generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_governors)" "Select CPU governor"
+			GOVERNOR=$PARAMETER
+		fi
 		if [[ -n $MIN_SPEED && -n $MAX_SPEED && -n $GOVERNOR ]]; then
-			dialog --colors --title " Apply and save changes " --backtitle "$BACKTITLE" --yes-label "OK" --no-label "Cancel" --yesno \
-			"\nCPU frequency will be within \Z1$(($MIN_SPEED / 1000))\Z0 and \Z1$(($MAX_SPEED / 1000)) MHz\Z0. The governor \Z1$GOVERNOR\Z0 will decide which speed to use within this range." 9 58
 			if [[ $? -eq 0 ]]; then
-				sed -i "s/MIN_SPEED=.*/MIN_SPEED=$MIN_SPEED/" /etc/default/cpufrequtils
-				sed -i "s/MAX_SPEED=.*/MAX_SPEED=$MAX_SPEED/" /etc/default/cpufrequtils
-				sed -i "s/GOVERNOR=.*/GOVERNOR=$GOVERNOR/" /etc/default/cpufrequtils
+				sed -i "s/ENABLE=.*/ENABLE=$ENABLE/" /etc/default/cpufrequtils	
+				if [[ $ENABLE == true ]]; then		
+					dialog --colors --title " Apply and save changes " --backtitle "$BACKTITLE" --yes-label "OK" --no-label "Cancel" --yesno \
+					"\nWARNING: cpufrequtils is deprecated.\nThis may not work on some boards.\n\nCPU frequency will be within \Z1$(($MIN_SPEED / 1000))\Z0 and \Z1$(($MAX_SPEED / 1000)) MHz\Z0. The governor \Z1$GOVERNOR\Z0 will decide which speed to use within this range." 9 58
+					sed -i "s/MIN_SPEED=.*/MIN_SPEED=$MIN_SPEED/" /etc/default/cpufrequtils
+					sed -i "s/MAX_SPEED=.*/MAX_SPEED=$MAX_SPEED/" /etc/default/cpufrequtils
+					sed -i "s/GOVERNOR=.*/GOVERNOR=$GOVERNOR/" /etc/default/cpufrequtils
+				fi
 				systemctl restart cpufrequtils
 				sync
 			fi
@@ -1687,3 +1699,4 @@ function jobs ()
 
 [[ -n $scripted ]] && exit
 }
+

--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1122,9 +1122,9 @@ function jobs ()
 		[[ ! -d /sys/devices/system/cpu/cpufreq/policy4 ]] && POLICY="policy0"
 		[[ -d /sys/devices/system/cpu/cpufreq/policy0 && -d /sys/devices/system/cpu/cpufreq/policy2 ]] && POLICY="policy2"
 		if [[ -n $(grep -w "ENABLE=true" /etc/default/cpufrequtils) ]]; then
-		   generic_select "true false" "Toggle ENABLE CPU frequency utilities."
+		   generic_select "true false" "Set ENABLE CPU frequency utilities."
 		else
-		   generic_select "false true" "Toggle ENABLE CPU frequency utilities."
+		   generic_select "false true" "Set ENABLE CPU frequency utilities."
 		fi
 		ENABLE=$PARAMETER
 		if [[ $ENABLE == true ]]; then

--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1141,7 +1141,7 @@ function jobs ()
 				sed -i "s/ENABLE=.*/ENABLE=$ENABLE/" /etc/default/cpufrequtils	
 				if [[ $ENABLE == true ]]; then		
 					dialog --colors --title " Apply and save changes " --backtitle "$BACKTITLE" --yes-label "OK" --no-label "Cancel" --yesno \
-					"\nWARNING: cpufrequtils is deprecated.\nThis may not work on some boards.\n\nCPU frequency will be within \Z1$(($MIN_SPEED / 1000))\Z0 and \Z1$(($MAX_SPEED / 1000)) MHz\Z0. The governor \Z1$GOVERNOR\Z0 will decide which speed to use within this range." 9 58
+					"\nWARNING: cpufrequtils is deprecated.\nThis may not work on some boards.\n\nCPU frequency will be within \Z1$(($MIN_SPEED / 1000))\Z0 and \Z1$(($MAX_SPEED / 1000)) MHz\Z0. The governor \Z1$GOVERNOR\Z0 will decide which speed to use within this range." 11 58
 					sed -i "s/MIN_SPEED=.*/MIN_SPEED=$MIN_SPEED/" /etc/default/cpufrequtils
 					sed -i "s/MAX_SPEED=.*/MAX_SPEED=$MAX_SPEED/" /etc/default/cpufrequtils
 					sed -i "s/GOVERNOR=.*/GOVERNOR=$GOVERNOR/" /etc/default/cpufrequtils

--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -60,7 +60,7 @@ while true; do
 	[[ -f /boot/boot.ini ]] && LIST+=( "Bootscript" "Edit boot script" )
 
 	if [[ -f /etc/default/cpufrequtils ]]; then
-		LIST+=( "CPU" "Set CPU speed and governor" )
+		LIST+=( "CPU" "Set CPU speed and governor. Deprecated." )
 	fi
 
 	AVAHIDSTATUS=$(service avahi-daemon status 2> /dev/null | grep -w active | grep -w running)


### PR DESCRIPTION
A change in [lib/functions/rootfs/distro-agnostic.sh](https://github.com/armbian/build/commit/66747a12e181eb9dab66a2b6deb85cdc60436fa7) disables  cpufrequtils by default.

Armbian-config "CPU - Set CPU speed and governor" requires cpufrequtils to be enabled in order to work.

Cpufrequtils is deprecated and troublesome on some boards but is still used and wanted by [forum members](https://forum.armbian.com/topic/30500-armbian-config-set-cpu-speed-and-governor-doesnt-apply/?do=findComment&comment=172511).

This change will add 'Deprecated' to the armbian-config menu item label and modify the associated job script to allow cpufrequtils to be enabled with a warning or disabled.

Tested on orangepizeroplus.
Jira reference number [AR-1883](https://armbian.atlassian.net/browse/AR-1883)

![Menu-deprecated](https://github.com/armbian/config/assets/61094841/24ea0e27-70a7-4df1-8769-025806563c58)
![set](https://github.com/armbian/config/assets/61094841/e625055e-610e-47a1-9f2c-fa69d878d3b5)
![Save-warning](https://github.com/armbian/config/assets/61094841/aad6ffa7-72b7-4adb-a2f4-76c2c14820b0)

[AR-1883]: https://armbian.atlassian.net/browse/AR-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ