### PR TITLE
debian-config-jobs Set CPU speed and governor ENABLE=false save

### DIFF
--- a/debian-config-jobs
+++ b/debian-config-jobs
@@ -1127,6 +1127,7 @@ function jobs ()
 		   generic_select "false true" "Set ENABLE CPU frequency utilities."
 		fi
 		ENABLE=$PARAMETER
+		sed -i "s/ENABLE=.*/ENABLE=$ENABLE/" /etc/default/cpufrequtils
 		if [[ $ENABLE == true ]]; then
 			dialog --title " Warning: DEPRECATED. THIS MAY NOT WORK ON SOME BOARDS "
 			generic_select "$(cat /sys/devices/system/cpu/cpufreq/$POLICY/scaling_available_frequencies 2>/dev/null || cat /sys/devices/system/cpu/cpufreq/$POLICY/cpuinfo_min_freq 2>/dev/null)" "Select minimum CPU speed"


### PR DESCRIPTION
Minor fix.  
Set CPU speed and governor, Set ENABLE=false not saving.

Tested on orangepizeroplus.
Jira reference number [AR-1883](https://armbian.atlassian.net/browse/AR-1883)

[AR-1883]: https://armbian.atlassian.net/browse/AR-1883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ