### PR TITLE
Fix freeze/defreeze menu not showing up

### DIFF
--- a/debian-config-submenu
+++ b/debian-config-submenu
@@ -30,7 +30,7 @@ while true; do
 	check_desktop
 
 	# check update status of BSP packages
-	local mark=$(apt-mark showhold | egrep "linux|armbian")
+	local mark=$(apt-mark showhold | egrep "linux|armbian-bsp|armbian-firmware|armbian-*-desktop")
 
 	# check if installer is on the system
 	if [[ -f /usr/sbin/armbian-install ]]; then


### PR DESCRIPTION
When image is built using BSPFREEZE="yes" then additional packages are being put on hold other than bsp/kernel/u-boot
This leads to armbian-config not showing "freeze" selection in system even after defreezing BSP packages

This PR narrows the regex matching bsp packages to be frozen/unfrozen - fixing the issue
